### PR TITLE
PL2: Fix battery capacity in power_profile

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -41,5 +41,5 @@
     </array>
     <item name="cpu.awake">1.6</item>
     <item name="cpu.idle">0.1</item>
-    <item name="battery.capacity">1000</item>
+    <item name="battery.capacity">3000</item>
 </device>


### PR DESCRIPTION
Apps relying on it (Franco kernel manager for e.g.) report wrong values otherwise

Signed-off-by: Aayush Gupta <aayushgupta219@gmail.com>
Change-Id: I781241ae512f0b5fb45cba42f1c808dd32633622